### PR TITLE
Repost feature in FeedPage and fixed bug in likes hover

### DIFF
--- a/src/Components/Posts/CreatePost/CreatePost.js
+++ b/src/Components/Posts/CreatePost/CreatePost.js
@@ -1,0 +1,69 @@
+import CreatePostStyle from "./CreatePostStyle";
+import { useState,useContext } from "react";
+import UserContext from "../../../contexts/UserContext";
+import UrlContext from "../../../contexts/UrlContext";
+import axios from "axios";
+
+export default function CreatePost () {
+    const URL = useContext(UrlContext);
+    const { userData } = useContext(UserContext);
+    const [loading, setLoading] = useState(false);
+    const token = localStorage.getItem('tokenLinker');
+    const [newPost, setNewPost] = useState({
+        url: "",
+        description: ""
+    })
+
+    function createNewPost(e) {
+        e.preventDefault();
+        setLoading(true);
+        
+        const config = {
+            headers: {
+                Authorization: `Bearer ${token}`
+            }
+        }
+        const promise = axios.post(`${URL}/posts`, newPost, config)
+        promise.then(() => {
+            window.location.reload(false);
+        })
+        promise.catch((error) => {
+            console.log(error.response.data);
+            alert('Houve um erro ao publicar seu link')
+            setLoading(false);
+        })
+    }
+
+    function handleInputChange(e) {
+        setNewPost({ ...newPost, [e.target.name]: e.target.value });
+    }
+    return (
+    <CreatePostStyle disable={loading}>
+        <img src={userData[0]?.profilePic} alt="" />
+        <form onSubmit={createNewPost}>
+            <h2>What are you going to share today?</h2>
+            <input
+                type='url'
+                name='url'
+                placeholder="Link to share"
+                value={newPost.url}
+                onChange={handleInputChange}
+                required
+                disabled={loading} />
+            <textarea
+                type='text'
+                rows='3'
+                name='description'
+                placeholder="description"
+                value={newPost.description}
+                onChange={handleInputChange}
+                disabled={loading} />
+            <button
+                type='submit'
+                disabled={loading}>
+                {loading ? 'Publishing...' : 'Publish'}
+            </button>
+        </form>
+    </CreatePostStyle>
+    );
+}

--- a/src/Components/Posts/CreatePost/CreatePostStyle.js
+++ b/src/Components/Posts/CreatePost/CreatePostStyle.js
@@ -1,0 +1,89 @@
+import styled from "styled-components";
+
+export default styled.div`
+background-color:#FFFFFF;
+margin-bottom:15px;
+display:flex;
+border-radius:10px;
+padding:18px 24px;
+width:100%;
+box-sizing:border-box;
+position:relative;
+img{
+    border-radius:50px;
+    height:50px;
+}
+h2{
+    font-size:20px;
+    color:#707070;
+    margin:8px 0 15px 0;
+    font-weight:300;
+}
+form{
+    padding:0 0 32px 20px;
+    display:flex;
+    flex-direction:column;
+    align-items:flex-start;
+    width:100%;
+}
+input, textarea{
+    opacity:${({ disable }) => disable ? '0.5' : '1'};
+    width:100%;
+    box-sizing:border-box;
+    background-color:#EFEFEF;
+    font-family:'Lato', sans-serif;
+    color:#949494;
+    font-weight:300;
+    font-size:15px;
+    border:none;
+    border-radius:5px;
+    padding:10px 15px;
+    margin-bottom:5px;
+}
+textarea{
+    height:70px;
+}
+
+button{
+    opacity:${({ disable }) => disable ? '0.5' : '1'};
+    position:absolute;
+    right:24px;
+    bottom:18px;
+    border:none;
+    border-radius:5px;
+    background-color:#1877F2;
+    color:#FFFFFF;
+    font-size:14px;
+    font-weight:700;
+    width:120px;
+    height:30px;
+}
+
+@media (max-width: 1130px) {
+    padding: 10px 18px;
+    margin-bottom:8px;
+    border-radius:0;
+    h2{
+        font-size:18px;
+        text-align:center;
+        width:100%;
+    }
+    img{
+        display:none;
+    }
+    input,textarea{
+        font-size:13px;
+    }
+    textarea{
+        height:54px;
+    }
+    button{
+        height:22px;
+        bottom:12px;
+        right:18px;
+    }
+    form{
+        padding:0 0 28px 0;
+    }
+  }
+`

--- a/src/Components/Posts/Post/ModalForPostActions.js
+++ b/src/Components/Posts/Post/ModalForPostActions.js
@@ -3,8 +3,8 @@ import { ThreeDots } from "react-loader-spinner";
 
 Modal.setAppElement('#root');
 
-export default function ModalForDelete (
-    {modalIsOpen,loading,closeModal,deletePost}) {
+export default function ModalForPostActions (
+    {modalIsOpen,loading,closeModal,postFunction,questionAnswers}) {
         
     return (
     <Modal
@@ -17,20 +17,20 @@ export default function ModalForDelete (
             :
             <h1
                 style={Modalh1Style}>
-                Are you sure you want <br /> to delete this post?
+                {questionAnswers[0]}
             </h1>}
         <div>
             <button
                 disabled={loading}
                 style={ModalNButtonStyle}
                 onClick={closeModal}>
-                No, go back
+                {questionAnswers[1]}
             </button>
             <button
                 disabled={loading}
                 style={ModalYButtonStyle}
-                onClick={deletePost}>
-                Yes, delete it
+                onClick={postFunction}>
+                {questionAnswers[2]}
             </button>
         </div>
     </Modal>)
@@ -46,7 +46,7 @@ const ModalCustomStyles = {
         transform: 'translate(-50%, -50%)',
         backgroundColor: '#333333',
         borderRadius: '50px',
-        padding: '40px 130px',
+        padding: '40px 30px',
         boxSizing: 'border-box',
         display: 'flex',
         flexDirection: 'column',
@@ -59,7 +59,8 @@ const Modalh1Style = {
     textAlign: 'center',
     fontWeight: '700',
     lineHeight: '40px',
-    marginBottom: '20px'
+    marginBottom: '20px',
+    width:'75%'
 }
 const ModalNButtonStyle = {
     border: 'none',

--- a/src/Components/Posts/Post/Post.js
+++ b/src/Components/Posts/Post/Post.js
@@ -1,16 +1,17 @@
-import styled from "styled-components";
+import { Container, tagStyle, Icons, Heart, RepostStyle, EditInput, URLdiv } from "./PostStyle";
 import axios from "axios";
 import { MdEdit } from "react-icons/md";
 import { AiFillDelete } from "react-icons/ai";
 import { FaRegHeart, FaHeart } from "react-icons/fa";
+import { BiRepost } from "react-icons/bi";
 import { ReactTagify } from "react-tagify";
 import { useNavigate } from "react-router-dom";
 import { useState, useRef, useEffect, useContext } from "react";
 import { Link } from "react-router-dom";
-import UserContext from "../../contexts/UserContext";
-import UrlContext from "../../contexts/UrlContext";
-
+import UserContext from "../../../contexts/UserContext";
+import UrlContext from "../../../contexts/UrlContext";
 import ReactTooltip from "react-tooltip";
+
 
 export default function Post({
   id,
@@ -18,18 +19,22 @@ export default function Post({
   urlData,
   description,
   likesCount,
+  repostCount,
   likes,
+  reposts,
   openModal,
   idUser,
 }) {
+
+
   const { userData } = useContext(UserContext);
   const URL = useContext(UrlContext);
   const [currDescription, setDescription] = useState(description);
   const [editPost, setEditMode] = useState(false);
   const [disable, setDisable] = useState(false);
-  const [liked, setLiked] = useState(false);
   const token = localStorage.getItem("tokenLinker");
   const navigate = useNavigate();
+
 
   function textWithoutHashtag(text) {
     return text?.replace("#", "");
@@ -122,7 +127,6 @@ export default function Post({
   }
 
   function addLike() {
-    setLiked(true);     
     const config = {
       headers: {
         Authorization: `Bearer ${token}`,
@@ -137,7 +141,6 @@ export default function Post({
     });
   }
   function removeLike() {
-    setLiked(false);
     console.log(id, token);
     const config = {
       headers: {
@@ -158,15 +161,15 @@ export default function Post({
       return `Ninguém curtiu esse post ainda`;
     } else {
       let user1 = "";
-      if (likes.filter((l) => l.id === userData[0].id).length > 0) {
+      if (likes.filter((l) => l.id === userData[0]?.id).length > 0) {
         user1 = "Você";
       } else user1 = likes[0]?.name;
       if (likesCount === 1) {
-        return `${user1}`;
+        return `${user1} curtiu`;
       } else if (likesCount === 2) {
-        return `${user1} e ${likes[1]?.name}`;
+        return `${user1} e ${likes[1]?.name} curtiram`;
       } else {
-        return `${user1},${likes[1]?.name} e outras ${likesCount - 2} pessoas`;
+        return `${user1},${likes[1]?.name} e outras ${likesCount - 2} pessoas curtiram`;
       }
     }
   }
@@ -178,14 +181,20 @@ export default function Post({
           <img src={userOwner.picture} alt="" />
         </Link>
         <Heart>
-          {likes.filter((l) => l.id === userData[0].id).length > 0 ? (
+          {likes.filter((l) => l.id === userData[0]?.id).length > 0 ? (
             <FaHeart style={{ color: "#AC0000" }} onClick={removeLike} />
           ) : (
             <FaRegHeart onClick={addLike} />
           )}
-          <p data-tip={messageLikes()}>{likesCount} likes</p>
+          <p data-tip={messageLikes()}>
+            {likesCount} likes</p>
           <ReactTooltip />
         </Heart>
+
+        <RepostStyle>
+          <BiRepost onClick={() => openModal(id,'repost')} />
+          <p>{repostCount} re-posts</p>
+        </RepostStyle>
       </div>
       <span>
         <div>
@@ -195,7 +204,7 @@ export default function Post({
           {userData[0]?.id === userOwner.id ? (
             <Icons>
               <MdEdit onClick={() => handleEdit("ClickIcon")} />
-              <AiFillDelete onClick={() => openModal(id)} />
+              <AiFillDelete onClick={() => openModal(id,'delete')} />
             </Icons>
           ) : (
             ""
@@ -229,174 +238,3 @@ export default function Post({
   );
 }
 
-const tagStyle = {
-  color: "white",
-  fontWeight: 700,
-  cursor: "pointer",
-};
-
-const Container = styled.div`
-  width: 100%;
-  box-sizing: border-box;
-  display: flex;
-  background-color: #171717;
-  border-radius: 10px;
-  padding: 18px;
-  margin: 15px 0;
-  img {
-    border-radius: 50px;
-    width: 50px;
-    height: 50px;
-  }
-  > div {
-    width: 50px;
-    margin-right: 20px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
-  h2 {
-    font-size: 20px;
-    color: #ffffff;
-    margin: 8px 0 10px 0;
-  }
-  p {
-    font-size: 17px;
-    color: #b7b7b7;
-    width: 100%;
-    text-align: start;
-  }
-  span {
-    width: 100%;
-    box-sizing: border-box;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-  }
-  span > div {
-    width: 100%;
-    display: flex;
-    justify-content: space-between;
-  }
-
-  @media (max-width: 1130px) {
-    margin: 5px 0;
-    padding: 12px;
-    border-radius: 0;
-    img {
-      width: 40px;
-      height: 40px;
-    }
-    > div {
-      width: 40px;
-      margin-right: 15px;
-    }
-    h2 {
-      font-size: 18px;
-    }
-    p {
-      font-size: 15px;
-    }
-  }
-`;
-
-const Icons = styled.div`
-  width: 50px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  color: #ffffff;
-  font-size: 20px;
-
-  @media (max-width: 1130px) {
-    font-size: 18px;
-  }
-`;
-const Heart = styled.div`
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin-top: 24px;
-  color: #ffffff;
-  font-size: 20px;
-  p {
-    font-size: 11px;
-    text-align: center;
-    line-height: 18px;
-  }
-`;
-const EditInput = styled.textarea`
-  opacity: ${({ changeOpacity }) => (changeOpacity ? "0.5" : "1")};
-  border: none;
-  border-radius: 5px;
-  width: 100%;
-  font-size: 16px;
-  font-family: "Lato", sans-serif;
-  color: #4c4c4c;
-  padding: 5px 10px;
-  box-sizing: border-box;
-  @media (max-width: 1130px) {
-    font-size: 14px;
-  }
-`;
-
-const URLdiv = styled.a`
-  display: flex;
-  align-items: center;
-  margin-top: 15px;
-  box-sizing: border-box;
-  height: 160px;
-  width: 100%;
-  border: 1px solid #c4c4c4;
-  border-radius: 10px;
-  overflow: hidden;
-
-  div {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 30%;
-    height: 100%;
-    overflow: hidden;
-  }
-  img {
-    height: 100%;
-    width: 100%;
-    object-fit: cover;
-    border-radius: 0;
-  }
-  span {
-    width: 70%;
-    padding: 25px;
-    box-sizing: border-box;
-  }
-  p {
-    color: #9b9595;
-    font-size: 12px;
-    margin: 10px 0;
-    line-height: 13px;
-  }
-  p:last-child {
-    color: #cecece;
-  }
-  h3 {
-    color: #cecece;
-    font-size: 16px;
-    text-align: start;
-  }
-
-  @media (max-width: 1130px) {
-    height: 120px;
-    h3 {
-      font-size: 10px;
-    }
-    p {
-      font-size: 9px;
-      margin: 5px 0;
-    }
-    span {
-      padding: 8px;
-    }
-  }
-`;

--- a/src/Components/Posts/Post/PostStyle.js
+++ b/src/Components/Posts/Post/PostStyle.js
@@ -1,0 +1,191 @@
+import styled from "styled-components";
+
+const tagStyle = {
+    color: "white",
+    fontWeight: 700,
+    cursor: "pointer",
+  };
+  
+  const Container = styled.div`
+    width: 100%;
+    box-sizing: border-box;
+    display: flex;
+    background-color: #171717;
+    border-radius: 10px;
+    padding: 18px;
+    margin: 15px 0;
+    img {
+      border-radius: 50px;
+      width: 50px;
+      height: 50px;
+    }
+    > div {
+      width: 50px;
+      margin-right: 20px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    h2 {
+      font-size: 20px;
+      color: #ffffff;
+      margin: 8px 0 10px 0;
+    }
+    p {
+      font-size: 17px;
+      color: #b7b7b7;
+      width: 100%;
+      text-align: start;
+    }
+    span {
+      width: 100%;
+      box-sizing: border-box;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+    }
+    span > div {
+      width: 100%;
+      display: flex;
+      justify-content: space-between;
+    }
+  
+    @media (max-width: 1130px) {
+      margin: 5px 0;
+      padding: 12px;
+      border-radius: 0;
+      img {
+        width: 40px;
+        height: 40px;
+      }
+      > div {
+        width: 40px;
+        margin-right: 15px;
+      }
+      h2 {
+        font-size: 18px;
+      }
+      p {
+        font-size: 15px;
+      }
+    }
+  `;
+  
+  const Icons = styled.div`
+    width: 50px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    color: #ffffff;
+    font-size: 20px;
+  
+    @media (max-width: 1130px) {
+      font-size: 18px;
+    }
+  `;
+  const Heart = styled.div`
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 24px;
+    color: #ffffff;
+    font-size: 20px;
+    p {
+      font-size: 11px;
+      text-align: center;
+      line-height: 18px;
+    }
+  `;
+
+  const RepostStyle = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 24px;
+  color: #ffffff;
+  font-size: 30px;
+  p {
+    font-size: 11px;
+    text-align: center;
+  }
+`;
+
+  const EditInput = styled.textarea`
+    opacity: ${({ changeOpacity }) => (changeOpacity ? "0.5" : "1")};
+    border: none;
+    border-radius: 5px;
+    width: 100%;
+    font-size: 16px;
+    font-family: "Lato", sans-serif;
+    color: #4c4c4c;
+    padding: 5px 10px;
+    box-sizing: border-box;
+    @media (max-width: 1130px) {
+      font-size: 14px;
+    }
+  `;
+  
+  const URLdiv = styled.a`
+    display: flex;
+    align-items: center;
+    margin-top: 15px;
+    box-sizing: border-box;
+    height: 160px;
+    width: 100%;
+    border: 1px solid #c4c4c4;
+    border-radius: 10px;
+    overflow: hidden;
+  
+    div {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 30%;
+      height: 100%;
+      overflow: hidden;
+    }
+    img {
+      height: 100%;
+      width: 100%;
+      object-fit: cover;
+      border-radius: 0;
+    }
+    span {
+      width: 70%;
+      padding: 25px;
+      box-sizing: border-box;
+    }
+    p {
+      color: #9b9595;
+      font-size: 12px;
+      margin: 10px 0;
+      line-height: 13px;
+    }
+    p:last-child {
+      color: #cecece;
+    }
+    h3 {
+      color: #cecece;
+      font-size: 16px;
+      text-align: start;
+    }
+  
+    @media (max-width: 1130px) {
+      height: 120px;
+      h3 {
+        font-size: 10px;
+      }
+      p {
+        font-size: 9px;
+        margin: 5px 0;
+      }
+      span {
+        padding: 8px;
+      }
+    }
+  `;
+  
+
+  export {tagStyle,Container,Icons,Heart,RepostStyle,EditInput,URLdiv}

--- a/src/Pages/HashtagPage.js
+++ b/src/Pages/HashtagPage.js
@@ -2,7 +2,7 @@ import { useEffect, useState, useContext} from "react";
 import { useParams } from "react-router-dom";
 import axios from "axios";
 import { ThreeDots } from "react-loader-spinner";
-import Post from "../Components/Posts/Post";
+import Post from "../Components/Posts/Post/Post";
 import { FeedPage } from "../shared/Feed/FeedPage";
 import UrlContext from "../contexts/UrlContext";
 

--- a/src/Pages/PostsPage.js
+++ b/src/Pages/PostsPage.js
@@ -1,25 +1,20 @@
 import { useEffect, useState, useContext } from "react";
 import axios from "axios";
 import { ThreeDots } from "react-loader-spinner";
-import styled from "styled-components";
-import Post from "../Components/Posts/Post";
+import Post from "../Components/Posts/Post/Post";
 import { FeedPage } from "../shared/Feed/FeedPage";
-import UserContext from "../contexts/UserContext";
 import UrlContext from "../contexts/UrlContext";
+import { useNavigate } from "react-router-dom";
 
 
 
 export default function PostsPage() {
     const URL = useContext(UrlContext);
-    const { userData } = useContext(UserContext);
     const [postList, setPostList] = useState(null);
     const [hashtags, setHashtags] = useState(null);
     const [loading, setLoading] = useState(false);
     const token = localStorage.getItem('tokenLinker');
-    const [newPost, setNewPost] = useState({
-        url: "",
-        description: ""
-    })
+    const navigate = useNavigate();
     
     function postsList (openModal) {
         return(
@@ -32,7 +27,9 @@ export default function PostsPage() {
                     urlData={p.urlData}
                     description={p.description}
                     likesCount={p.likesCount}
+                    repostCount={p.repostCount}
                     likes={p.likes}
+                    reposts={p.reposts}
                     openModal={openModal}
                     idUser={p.userOwner.id}
                 />
@@ -45,34 +42,6 @@ export default function PostsPage() {
     );
 }
 
-    const forms = (
-        <CreatePost disable={loading}>
-            <img src={userData[0]?.profilePic} alt="" />
-            <form onSubmit={createNewPost}>
-                <h2>What are you going to share today?</h2>
-                <input
-                    type='url'
-                    name='url'
-                    placeholder="Link to share"
-                    value={newPost.url}
-                    onChange={handleInputChange}
-                    required
-                    disabled={loading} />
-                <textarea
-                    type='text'
-                    rows='3'
-                    name='description'
-                    placeholder="description"
-                    value={newPost.description}
-                    onChange={handleInputChange}
-                    disabled={loading} />
-                <button
-                    type='submit'
-                    disabled={loading}>
-                    {loading ? 'Publishing...' : 'Publish'}
-                </button>
-            </form>
-        </CreatePost>);
 
     useEffect(() => {
         const config = {
@@ -87,8 +56,11 @@ export default function PostsPage() {
 
         });
         promise.catch((error) => {
-            console.log(error.response.data);
-            alert("An error occured while trying to fetch the posts, please refresh the page");
+            if(error.response.status===401){
+                navigate("/")
+            } else {
+                alert("An error occured while trying to fetch the posts, please refresh the page");
+            }
         });
 
         axios.get(`${URL}/hashtags`, config)
@@ -108,123 +80,9 @@ export default function PostsPage() {
 
     }, [token, URL]);
 
-    function createNewPost(e) {
-        e.preventDefault();
-        setLoading(true);
-        // const URL = 'https://backlinkr.herokuapp.com/posts';
-        
-        const config = {
-            headers: {
-                Authorization: `Bearer ${token}`
-            }
-        }
-        const promise = axios.post(`${URL}/posts`, newPost, config)
-        promise.then(() => {
-            window.location.reload(false);
-        })
-        promise.catch((error) => {
-            console.log(error.response.data);
-            alert('Houve um erro ao publicar seu link')
-            setLoading(false);
-        })
-    }
-
-    function handleInputChange(e) {
-        setNewPost({ ...newPost, [e.target.name]: e.target.value });
-    }
-
+    
 
     return (
-            <FeedPage title='timeline' forms={forms} posts={postsList} hashtags={hashtags} />
+            <FeedPage title='timeline' forms={true} posts={postsList} hashtags={hashtags} />
     );
 }
-
-
-
-const CreatePost = styled.div`
-background-color:#FFFFFF;
-margin-bottom:15px;
-display:flex;
-border-radius:10px;
-padding:18px 24px;
-width:100%;
-box-sizing:border-box;
-position:relative;
-img{
-    border-radius:50px;
-    height:50px;
-}
-h2{
-    font-size:20px;
-    color:#707070;
-    margin:8px 0 15px 0;
-    font-weight:300;
-}
-form{
-    padding:0 0 32px 20px;
-    display:flex;
-    flex-direction:column;
-    align-items:flex-start;
-    width:100%;
-}
-input, textarea{
-    opacity:${({ disable }) => disable ? '0.5' : '1'};
-    width:100%;
-    box-sizing:border-box;
-    background-color:#EFEFEF;
-    font-family:'Lato', sans-serif;
-    color:#949494;
-    font-weight:300;
-    font-size:15px;
-    border:none;
-    border-radius:5px;
-    padding:10px 15px;
-    margin-bottom:5px;
-}
-textarea{
-    height:70px;
-}
-
-button{
-    opacity:${({ disable }) => disable ? '0.5' : '1'};
-    position:absolute;
-    right:24px;
-    bottom:18px;
-    border:none;
-    border-radius:5px;
-    background-color:#1877F2;
-    color:#FFFFFF;
-    font-size:14px;
-    font-weight:700;
-    width:120px;
-    height:30px;
-}
-
-@media (max-width: 1130px) {
-    padding: 10px 18px;
-    margin-bottom:8px;
-    border-radius:0;
-    h2{
-        font-size:18px;
-        text-align:center;
-        width:100%;
-    }
-    img{
-        display:none;
-    }
-    input,textarea{
-        font-size:13px;
-    }
-    textarea{
-        height:54px;
-    }
-    button{
-        height:22px;
-        bottom:12px;
-        right:18px;
-    }
-    form{
-        padding:0 0 28px 0;
-    }
-  }
-`

--- a/src/Pages/TelaUser.js
+++ b/src/Pages/TelaUser.js
@@ -4,7 +4,7 @@ import axios from "axios"
 import { ThreeDots } from "react-loader-spinner";
 import { useEffect, useState, useContext} from "react";
 // import styled from "styled-components";
-import Post from "../Components/Posts/Post"
+import Post from "../Components/Posts/Post/Post"
 import { FeedPage } from "../shared/Feed/FeedPage";
 import UrlContext from "../contexts/UrlContext";
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,5 @@ import "./styles/index.css";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
-  <React.StrictMode>
     <App />
-  </React.StrictMode>
 );

--- a/src/shared/Feed/FeedPage.js
+++ b/src/shared/Feed/FeedPage.js
@@ -1,17 +1,20 @@
-import { Container, Title, InnerContainer, RightInnerContainer, LeftInnerContainer, SubTitle, TextContent, SubItems} from "./FeedStyle";
+import { Container, Title, InnerContainer, RightInnerContainer, LeftInnerContainer, SubTitle, TextContent, SubItems } from "./FeedStyle";
 import { useNavigate } from "react-router-dom";
 import Header from "../Header";
-import ModalForDelete from "../../Components/Posts/ModalForDelete";
+import ModalForPostActions from "../../Components/Posts/Post/ModalForPostActions";
+import CreatePost from "../../Components/Posts/CreatePost/CreatePost";
 import { useContext, useState } from "react";
 import axios from "axios";
 import UrlContext from "../../contexts/UrlContext";
 import SearchNewUpdates from "../../Components/Posts/SearchNewUpdates";
 
-export function FeedPage({title, forms, posts, hashtags}){
+export function FeedPage({ title, forms, posts, hashtags }) {
     const navigate = useNavigate();
     const URL = useContext(UrlContext);
     const [postToDelete, setDelete] = useState('');
-    const [modalIsOpen, setIsOpen] = useState(false);
+    const [postToRepost, setRepost] = useState('');
+    const [deleteIsOpen, setDeleteOpen] = useState(false);
+    const [repostIsOpen, setRepostOpen] = useState(false);
     const [loading, setLoading] = useState(false);
     const token = localStorage.getItem('tokenLinker');
 
@@ -28,61 +31,107 @@ export function FeedPage({title, forms, posts, hashtags}){
         })
         promise.catch((error) => {
             setLoading(false);
-            closeModal();
+            closeModal('delete');
             console.log(error.response.data);
             alert("The post could not be deleted");
         })
     }
 
-    function openModal(id) {
-        setIsOpen(true);
-        setDelete(id);
+    function addRepost() {
+        setLoading(true);
+        const config = {
+            headers: {
+                Authorization: `Bearer ${token}`
+            }
+        }
+        const promise = axios.post(`${URL}/repost/${postToRepost}`, config);
+        promise.then(() => {
+            window.location.reload(false);
+        })
+        promise.catch((error) => {
+            setLoading(false);
+            closeModal('repost');
+            console.log(error.response.data);
+            alert("The post could not be reposted");
+        })
     }
 
-    function closeModal() {
-        setIsOpen(false);
+    function openModal(id, field) {
+        switch (field) {
+            case 'repost':
+                setRepostOpen(true);
+                setRepost(id);
+                break
+            case 'delete':
+                setDeleteOpen(true);
+                setDelete(id);
+                break
+            default:
+                break
+        }
+    }
+
+    function closeModal(field) {
+        switch (field) {
+            case 'repost':
+                setRepostOpen(false);
+                break
+            case 'delete':
+                setDeleteOpen(false);
+                break
+            default:
+                break
+        }
     }
     return (
-       <>
-       <Header/>
-        <Container>
-            <Title>
-                {title}
-            </Title>
+        <>
+            <Header />
+            <Container>
+                <Title>
+                    {title}
+                </Title>
 
 
-            <InnerContainer>
-                <LeftInnerContainer>
-                    {forms ? forms : null}
-                    {posts(openModal)}
-                    
-                    <SearchNewUpdates>
-                    </SearchNewUpdates>
+                <InnerContainer>
+                    <LeftInnerContainer>
+                        {forms ? <CreatePost /> : null}
+                        {posts(openModal)}
 
-                </LeftInnerContainer>
-                <RightInnerContainer>
-                    <SubTitle>
-                        trendings
-                    </SubTitle>
-                    <SubItems>
+                        <SearchNewUpdates>
+                        </SearchNewUpdates>
 
-                    { hashtags ?
-                    hashtags.map((item,index)=>{
-                      return <TextContent key={index} onClick={()=>navigate(`/hashtag/${item}`)} >
-                        {`#${item}`}
-                      </TextContent>    
-                    })
-                    : null } 
-                    </SubItems>
-                </RightInnerContainer>
-            </InnerContainer>
-            <ModalForDelete
-            modalIsOpen={modalIsOpen}
-            loading={loading}
-            closeModal={closeModal}
-            deletePost={deletePost}
-            />
-        </Container>
-       </>
+                    </LeftInnerContainer>
+                    <RightInnerContainer>
+                        <SubTitle>
+                            trendings
+                        </SubTitle>
+                        <SubItems>
+
+                            {hashtags ?
+                                hashtags.map((item, index) => {
+                                    return <TextContent key={index} onClick={() => navigate(`/hashtag/${item}`)} >
+                                        {`#${item}`}
+                                    </TextContent>
+                                })
+                                : null}
+                        </SubItems>
+                    </RightInnerContainer>
+                </InnerContainer>
+                <ModalForPostActions
+                    modalIsOpen={deleteIsOpen}
+                    loading={loading}
+                    closeModal={()=>closeModal('delete')}
+                    postFunction={deletePost}
+                    questionAnswers={['Are you sure you want to delete this post?','No, go back','Yes, delete it']}
+                />
+                <ModalForPostActions
+                    modalIsOpen={repostIsOpen}
+                    loading={loading}
+                    closeModal={()=>closeModal('repost')}
+                    postFunction={addRepost}
+                    questionAnswers={['Do you want to re-post this link?','No, cancel','Yes, share!']}
+                />
+            </Container>
+        </>
     );
 }


### PR DESCRIPTION
Enabled new feature: re-post a specific post
requires: clicking in re-post icon
response: shows a confirmation modal where you can cancel the action or proceed with re-post (re-post function per se is failing with 401 status code)

Also new:
- see number of re-posts of each post
- like information now disappears when mouse leaves 'like' button
